### PR TITLE
docs: Add GitHub issue and pull request templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,79 @@
+name: 🐛 Bug report
+description: Report a bug or unexpected behavior in jaclks
+title: "[Bug]: "
+labels: [bug]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a bug!
+        Before submitting, please search [existing issues](https://github.com/BossZou/jaclks/issues?q=is%3Aissue) to avoid duplicates.
+  - type: textarea
+    id: bug-description
+    attributes:
+      label: Describe the bug
+      description: A clear and concise description of what the bug is.
+      placeholder: e.g. Calling Thread::Sleep with a negative value hangs the process.
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to reproduce
+      description: Provide a minimal code snippet and the commands used to build and run it.
+      placeholder: |
+        Code:
+        ```cpp
+        // minimal reproduction
+        ```
+
+        Build and run:
+        ```shell
+        cmake .. -DCMAKE_BUILD_TYPE=Debug -DENABLE_GTEST=ON
+        make
+        ctest --verbose --output-on-failure --build-config Debug
+        ```
+    validations:
+      required: true
+  - type: textarea
+    id: expected-behavior
+    attributes:
+      label: Expected behavior
+      description: What did you expect to happen?
+    validations:
+      required: true
+  - type: textarea
+    id: actual-behavior
+    attributes:
+      label: Actual behavior
+      description: What actually happened?
+    validations:
+      required: true
+  - type: dropdown
+    id: os
+    attributes:
+      label: Operating system
+      options:
+        - Ubuntu 22.04
+        - Ubuntu 24.04
+        - macOS 15
+        - Other
+    validations:
+      required: true
+  - type: input
+    id: compiler
+    attributes:
+      label: Compiler version
+      description: Output of `g++ --version`.
+      placeholder: e.g. g++ (Ubuntu 13.2.0-23ubuntu4) 13.2.0
+  - type: input
+    id: cmake-version
+    attributes:
+      label: CMake version
+      description: Output of `cmake --version`.
+      placeholder: e.g. cmake version 3.28.3
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional context
+      description: Logs, stack traces, screenshots, or anything else that might help.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,1 +1,1 @@
-blank_issues_enabled: true
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/.github/ISSUE_TEMPLATE/documentation_issue.yml
+++ b/.github/ISSUE_TEMPLATE/documentation_issue.yml
@@ -1,0 +1,35 @@
+name: 📚 Documentation issue
+description: Report an error or outdated content in the documentation
+title: "[Docs]: "
+labels: [documentation]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for helping improve the documentation!
+        Before submitting, please search [existing issues](https://github.com/BossZou/jaclks/issues?q=is%3Aissue) to avoid duplicates.
+  - type: input
+    id: location
+    attributes:
+      label: Affected page or file
+      description: Where is the documentation problem?
+      placeholder: e.g. README.md - Build from source section
+    validations:
+      required: true
+  - type: textarea
+    id: problem
+    attributes:
+      label: What is wrong?
+      description: Describe the error, outdated content, or missing information.
+    validations:
+      required: true
+  - type: textarea
+    id: suggestion
+    attributes:
+      label: Suggested fix
+      description: How should the documentation be corrected? (optional)
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional context
+      description: Screenshots, links, or anything else that might help.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,40 @@
+name: ✨ Feature request
+description: Suggest a new feature or improvement for jaclks
+title: "[Feature]: "
+labels: [enhancement]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting a feature!
+        Before submitting, please search [existing issues](https://github.com/BossZou/jaclks/issues?q=is%3Aissue) to avoid duplicates.
+  - type: textarea
+    id: problem
+    attributes:
+      label: Is your feature request related to a problem?
+      description: A clear and concise description of what the problem is.
+      placeholder: e.g. I'm always frustrated when ...
+    validations:
+      required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: Describe the solution you'd like
+      description: Describe the feature you want. For new classes, sketch the API following jaclks' Java-style conventions.
+      placeholder: |
+        e.g. Add an ArrayList<T> class with methods:
+        - add(const T& element)
+        - get(size_t index)
+        - remove(size_t index)
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Describe alternatives you've considered
+      description: A clear and concise description of any alternative solutions or features you've considered.
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional context
+      description: Add any other context, references, or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/other.yml
+++ b/.github/ISSUE_TEMPLATE/other.yml
@@ -1,0 +1,28 @@
+name: 📝 Other
+description: Anything that does not fit the other templates
+title: "[Other]: "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this template for anything that does not fit 🐛 Bug report, ✨ Feature request, 📚 Documentation issue, or ❓ Usage question.
+  - type: textarea
+    id: topic
+    attributes:
+      label: What is this about?
+      description: Briefly describe the topic of this issue.
+      placeholder: e.g. Build system, packaging, repository maintenance, ...
+    validations:
+      required: true
+  - type: textarea
+    id: details
+    attributes:
+      label: Details
+      description: Provide the details of the issue.
+    validations:
+      required: true
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional context
+      description: Screenshots, links, or anything else that might help.

--- a/.github/ISSUE_TEMPLATE/usage_question.yml
+++ b/.github/ISSUE_TEMPLATE/usage_question.yml
@@ -1,0 +1,45 @@
+name: ❓ Usage question
+description: Ask a question about using jaclks
+title: "[Question]: "
+labels: [question]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Please check the [README](https://github.com/BossZou/jaclks#readme) and search [existing issues](https://github.com/BossZou/jaclks/issues?q=is%3Aissue) before asking.
+        For bug reports, please use the [🐛 Bug report](https://github.com/BossZou/jaclks/issues/new?template=bug_report.yml) template instead.
+  - type: textarea
+    id: goal
+    attributes:
+      label: What are you trying to do?
+      description: Describe what you want to achieve with jaclks.
+    validations:
+      required: true
+  - type: textarea
+    id: code
+    attributes:
+      label: Code and commands
+      description: Paste the code snippet and build commands you tried.
+      placeholder: |
+        ```cpp
+        // your code
+        ```
+
+        ```shell
+        cmake .. -DCMAKE_BUILD_TYPE=Debug -DENABLE_GTEST=ON
+        make
+        ```
+  - type: dropdown
+    id: os
+    attributes:
+      label: Operating system
+      options:
+        - Ubuntu 22.04
+        - Ubuntu 24.04
+        - macOS 15
+        - Other
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional context
+      description: Error messages, links, or anything that helps understand your question.

--- a/.github/PULL_REQUEST_TEMPLATE/bugfix.md
+++ b/.github/PULL_REQUEST_TEMPLATE/bugfix.md
@@ -1,0 +1,31 @@
+## Bug description
+
+<!-- What was the bug? Describe the incorrect behavior. -->
+
+## Root cause
+
+<!-- Why did it happen? Point to the code path that caused it. -->
+
+## Fix
+
+<!-- What does this PR change and how does it address the root cause? -->
+
+## Related issue
+
+<!-- Link to the issue this PR fixes, e.g. Fixes #123. -->
+
+## Test plan
+
+<!-- How was the fix verified? List the commands you ran. -->
+
+```shell
+cmake .. -DCMAKE_BUILD_TYPE=Debug -DENABLE_GTEST=ON
+make
+ctest --verbose --output-on-failure --build-config Debug
+```
+
+## Checklist
+
+- [ ] Regression test added that fails before this fix and passes after
+- [ ] Code passes `cpplint` and follows `.clang-format`
+- [ ] `CHANGELOG.md` updated (enforced by CI)

--- a/.github/PULL_REQUEST_TEMPLATE/ci.md
+++ b/.github/PULL_REQUEST_TEMPLATE/ci.md
@@ -1,0 +1,21 @@
+## Summary
+
+<!-- Which workflow or CI configuration does this PR change? e.g. .github/workflows/ubuntu-build.yml -->
+
+## Motivation
+
+<!-- Why is this change needed? What CI gap does it close? -->
+
+## Related issue
+
+<!-- Link to the issue this PR addresses, e.g. Closes #123. -->
+
+## Validation
+
+<!-- Link to a successful workflow run that proves the new CI configuration works. -->
+
+## Checklist
+
+- [ ] No source code changes in this PR
+- [ ] The affected workflow(s) ran successfully on this PR
+- [ ] `CHANGELOG.md` updated (enforced by CI)

--- a/.github/PULL_REQUEST_TEMPLATE/documentation.md
+++ b/.github/PULL_REQUEST_TEMPLATE/documentation.md
@@ -1,0 +1,18 @@
+## Summary
+
+<!-- What documentation changed? Mention the files, e.g. README.md, docs/, CHANGELOG.md. -->
+
+## Motivation
+
+<!-- Why is this documentation change needed? -->
+
+## Related issue
+
+<!-- Link to the issue this PR addresses, e.g. Closes #123. -->
+
+## Checklist
+
+- [ ] No source code changes in this PR
+- [ ] All links and code snippets verified
+- [ ] Spelling and grammar checked
+- [ ] `CHANGELOG.md` updated (enforced by CI)

--- a/.github/PULL_REQUEST_TEMPLATE/feature.md
+++ b/.github/PULL_REQUEST_TEMPLATE/feature.md
@@ -1,0 +1,32 @@
+## Summary
+
+<!-- Briefly describe the new feature and what it adds to jaclks. -->
+
+## Motivation
+
+<!-- Why is this feature needed? What problem does it solve? -->
+
+## API design
+
+<!-- Describe the public API (classes, interfaces, method signatures) following jaclks' Java-style conventions. -->
+
+## Related issue
+
+<!-- Link to the issue this PR implements, e.g. Closes #123. -->
+
+## Test plan
+
+<!-- How was this tested? List the commands you ran. -->
+
+```shell
+cmake .. -DCMAKE_BUILD_TYPE=Debug -DENABLE_GTEST=ON
+make
+ctest --verbose --output-on-failure --build-config Debug
+```
+
+## Checklist
+
+- [ ] Unit tests added for the new feature
+- [ ] Code passes `cpplint` and follows `.clang-format`
+- [ ] `CHANGELOG.md` updated (enforced by CI)
+- [ ] Documentation updated if applicable

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,3 +53,4 @@ Please mark all change in change log and use the issue from GitHub
 ## Document
 - [#22](https://github.com/BossZou/jaclks/pull/22) Add license Apache 2.0 and code quality badge
 - [#38](https://github.com/BossZou/jaclks/pull/38) Add CHANGELOG file
+- [#63](https://github.com/BossZou/jaclks/pull/63) Add issue and pull request templates


### PR DESCRIPTION
## Summary

Add GitHub issue and pull request templates.

### Issue templates (YAML forms)

- 🐛 Bug report — auto-labeled `bug`, includes OS/compiler/CMake fields and reproduction steps
- ✨ Feature request — auto-labeled `enhancement`
- 📚 Documentation issue — auto-labeled `documentation`
- ❓ Usage question — auto-labeled `question`, links to the bug template when applicable
- 📝 Other — catch-all template for anything else

`config.yml` disables blank issues, since the Other template now covers unclassified submissions.

### PR templates

- `feature.md` — feature development
- `bugfix.md` — bug fixes
- `documentation.md` — documentation updates
- `ci.md` — CI configuration changes

All PR templates include the `CHANGELOG.md` checklist item since CI enforces it.

Note: GitHub has no template chooser for PRs; templates are selected via the `?template=` query parameter, e.g. `?template=feature.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
